### PR TITLE
add MANIFEST.in to include required files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include requirements.txt
+include README.rst
+include LICENSE


### PR DESCRIPTION
otherwise build fails on Pypi's SDIST archive:

```
>>> Emerging (1 of 1) dev-python/pyps4-2ndscreen-1.2.0::HomeAssistantRepository
>>> Failed to emerge dev-python/pyps4-2ndscreen-1.2.0, Log file:
>>>  '/var/tmp/portage/dev-python/pyps4-2ndscreen-1.2.0/temp/build.log'
>>> Jobs: 0 of 1 complete, 1 failed                 Load avg: 5.99, 5.96, 5.17
 * Package:    dev-python/pyps4-2ndscreen-1.2.0
 * Repository: HomeAssistantRepository
 * Maintainer: b@edevau.net
 * Upstream:   ktnrg45@gmail.com
 * USE:        abi_x86_64 amd64 elibc_glibc kernel_linux python_targets_python3_8 test userland_GNU
 * FEATURES:   network-sandbox preserve-libs sandbox userpriv usersandbox
>>> Unpacking source...
>>> Unpacking pyps4-2ndscreen-1.2.0.tar.gz to /var/tmp/portage/dev-python/pyps4-2ndscreen-1.2.0/work
>>> Source unpacked in /var/tmp/portage/dev-python/pyps4-2ndscreen-1.2.0/work
>>> Preparing source in /var/tmp/portage/dev-python/pyps4-2ndscreen-1.2.0/work/pyps4_2ndscreen-1.2.0 ...
>>> Source prepared.
>>> Configuring source in /var/tmp/portage/dev-python/pyps4-2ndscreen-1.2.0/work/pyps4_2ndscreen-1.2.0 ...
>>> Source configured.
>>> Compiling source in /var/tmp/portage/dev-python/pyps4-2ndscreen-1.2.0/work/pyps4_2ndscreen-1.2.0 ...
 * python3_8: running distutils-r1_run_phase distutils-r1_python_compile
python3.8 setup.py build -j 10
Traceback (most recent call last):
  File "setup.py", line 10, in <module>
    REQUIRES = list(open('requirements.txt'))
FileNotFoundError: [Errno 2] No such file or directory: 'requirements.txt'
 * ERROR: dev-python/pyps4-2ndscreen-1.2.0::HomeAssistantRepository failed (compile phase):
 *   (no error message)
```
hope this works, cannot test it.