### PR TITLE
Removing state pollution in 'data'

### DIFF
--- a/tests/test_media_art.py
+++ b/tests/test_media_art.py
@@ -8,6 +8,7 @@ from asynctest import CoroutineMock as mock_coro
 from asynctest import Mock
 
 from pyps4_2ndscreen import media_art as media
+import copy
 
 pytestmark = pytest.mark.asyncio
 
@@ -331,7 +332,7 @@ async def test_fetch_errors():
 
 async def test_result_item_missing_data():
     """Test Parsing with missing keys returns None."""
-    data = MOCK_DATA
+    data = copy.deepcopy(MOCK_DATA)
     data.pop("gameContentTypesList")
     data.pop("title_name")
     mock_response = Mock()


### PR DESCRIPTION
This PR aims to improve test reliability of test `test_result_item_missing_data` by removing state pollution of `data` by making a deepcopy.

The test can fail in this way by running `pip3 install pytest-repeat; python3 -m pytest --count=2 tests/test_media_art.py::test_result_item_missing_data`:
```
    async def test_result_item_missing_data():
        """Test Parsing with missing keys returns None."""
        data = MOCK_DATA
>       data.pop("gameContentTypesList")
E       KeyError: 'gameContentTypesList'

tests/test_media_art.py:335: KeyError
```

It may be better to clean state pollutions so that some other tests won't fail in the future due to the shared state pollution.